### PR TITLE
Extend API - add batch predict endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,8 @@ server: uvicorn
 
 ```
 
+## API Documentation
+Check the docs here: `http://localhost:8000/docs` to see the full schema. These docs can also be used as a quick way to test `POST` requests.
+
 ## Troubleshooting
 If you run into errors when executing the commands ``bin/download_model``, ``bin/start_server``, or ``bin/test_request``, try setting the write permissions of the file as shown in the example below:<br>``chmod +x bin/download_model``

--- a/bin/start_server
+++ b/bin/start_server
@@ -1,3 +1,3 @@
 # !bin/bash
 
-uvicorn src.api:app
+uvicorn src.api:app --reload

--- a/src/api.py
+++ b/src/api.py
@@ -15,10 +15,29 @@ class Classification_Response(BaseModel):
     classification: str
     confidence: float
 
+class Classification_Request_Batch(BaseModel):
+    texts: List[str]
+
+class Classification_Response_Batch(BaseModel):
+    predictions: List[Classification_Response]
+
 @app.post("/predict", response_model=Classification_Response)
 def predict(request: Classification_Request, model: Model = Depends(get_model)):
     classification, confidence, probabilities = model.predict(request.text)
 
     return Classification_Response(
         classification = classification, confidence = confidence, probabilities=probabilities
+    )
+
+@app.post("/predict_batch", response_model=Classification_Response_Batch)
+def predict_batch(request: Classification_Request_Batch, model: Model = Depends(get_model)):
+    Text_predictions = request.texts
+    for text in text_predictions:
+        classification, confidence, probabilities = model.predict(text.text)
+        text["classification"] = classification
+        text["confidence"] = confidence
+        text["probabilities"] = probabilities
+
+    return Classification_Response_Batch(
+        text_predictions
     )

--- a/src/api.py
+++ b/src/api.py
@@ -1,3 +1,7 @@
+"""
+API endpoints for text category prediction
+"""
+
 from typing import Dict, List
 
 from fastapi import Depends, FastAPI
@@ -7,36 +11,33 @@ from .classifier.model import Model, get_model
 
 app = FastAPI()
 
-class Classification_Request(BaseModel):
+class ClassificationRequest(BaseModel):
     text: str
 
-class Classification_Response(BaseModel):
+class ClassificationResponse(BaseModel):
     probabilities: Dict[str, float]
     classification: str
     confidence: float
 
-class Classification_Request_Batch(BaseModel):
+class ClassificationRequestBatch(BaseModel):
     text_list: List[str]
 
-class Classification_Response_Batch(BaseModel):
-    predictions: List
-
-@app.post("/predict", response_model=Classification_Response)
-def predict(request: Classification_Request, model: Model = Depends(get_model)):
+@app.post("/predict", response_model=ClassificationResponse)
+def predict(request: ClassificationRequest, model: Model = Depends(get_model)):
     classification, confidence, probabilities = model.predict(request.text)
 
-    return Classification_Response(
-        classification = classification, confidence = confidence, probabilities=probabilities
+    return ClassificationResponse(
+        classification=classification, confidence=confidence, probabilities=probabilities
     )
 
 @app.post("/predict_batch")
-def predict_batch(request: Classification_Request_Batch, model: Model = Depends(get_model)):
+def predict_batch(request: ClassificationRequestBatch, model: Model = Depends(get_model)):
     predictions_list = []
     for text in request.text_list:
         classification, confidence, probabilities = model.predict(text)
-    
-        prediction = Classification_Response(
-            classification = classification, confidence = confidence, probabilities=probabilities
+
+        prediction = ClassificationResponse(
+            classification=classification, confidence=confidence, probabilities=probabilities
         )
         predictions_list.append({"text": text, "prediction": prediction})
 

--- a/src/api.py
+++ b/src/api.py
@@ -31,13 +31,13 @@ def predict(request: Classification_Request, model: Model = Depends(get_model)):
 
 @app.post("/predict_batch")
 def predict_batch(request: Classification_Request_Batch, model: Model = Depends(get_model)):
-    predictions = []
+    predictions_list = []
     for text in request.text_list:
         classification, confidence, probabilities = model.predict(text)
     
-        predicted = Classification_Response(
+        prediction = Classification_Response(
             classification = classification, confidence = confidence, probabilities=probabilities
         )
-        predictions.append(predicted)
+        predictions_list.append({"text": text, "prediction": prediction})
 
-    return predictions
+    return predictions_list


### PR DESCRIPTION
This PR adds API functionality for making predictions in a batch. It adds an endpoint that accepts an array of text to make predictions on.